### PR TITLE
Exclude com.google.code.findbugs:jsr305 from guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${dep.guava.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Java APIs -->


### PR DESCRIPTION
`com.google.code.findbugs:jsr305` is an explicit dependency starting in [Guava 22.0](https://repo1.maven.org/maven2/com/google/guava/guava/22.0/guava-22.0.pom), so we should exclude it going forward.

@jhaber 