### PR TITLE
Use finalName insteadof outputFile in the shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <configuration>
-            <outputFile>${project.build.directory}/${basepom.jar.name.format}-shaded.jar</outputFile>
+            <finalName>${basepom.jar.name.format}-shaded.jar</finalName>
             <shadedArtifactAttached>false</shadedArtifactAttached>
           </configuration>
         </plugin>
@@ -2012,7 +2012,6 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-shade-plugin</artifactId>
               <configuration>
-                <outputFile combine.self="override" />
                 <finalName>${basepom.jar.name.format}</finalName>
                 <shadedArtifactAttached>true</shadedArtifactAttached>
               </configuration>


### PR DESCRIPTION
Using `outputFile` was breaking downstream projects using `finalName`. Rather than have propagate `<outputFile combine.self="override" />` downstream we thought it be safe just to remove the use of `outputFile` all together.

@jhaber 