### PR TITLE
Ignore pmd on generated sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,8 +179,11 @@
           <artifactId>maven-pmd-plugin</artifactId>
           <configuration>
             <excludeRoots combine.children="append">
+              <!-- Generated code from annotation processors like Immutables -->
               <excludeRoot>target/generated-sources/annotations</excludeRoot>
+              <!-- Generated code from protoc-bundled-plugin -->
               <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+              <!-- Generated code from recompile-protos-maven-plugin -->
               <excludeRoot>target/generated-sources/dependency-protobufs</excludeRoot>
             </excludeRoots>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,17 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <configuration>
+            <excludeRoots combine.children="append">
+              <excludeRoot>target/generated-sources/annotations</excludeRoot>
+              <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+              <excludeRoot>target/generated-sources/dependency-protobufs</excludeRoot>
+            </excludeRoots>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>${dep.plugin.plugin.version}</version>
         </plugin>


### PR DESCRIPTION
To prevent PMD from OOMing or getting really sad on big generated classes. We also don't necessarily care about violations since the code is generated. Unfortunately I couldn't find a way to globally exclude `target/generated-sources`

@stevegutz 