### PR TITLE
Suppress linkXRef warning from maven-pmd-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <configuration>
+            <linkXRef>false</linkXRef>
             <excludeRoots combine.children="append">
               <!-- Generated code from annotation processors like Immutables -->
               <excludeRoot>target/generated-sources/annotations</excludeRoot>


### PR DESCRIPTION
Suppress the warning `[WARNING] Unable to locate Source XRef to link to - DISABLED` in build logs from the `maven-pmd-plugin`