### PR TITLE
Bumps guava to 22, adds a bunch of others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <dep.classmate.version>1.1.0</dep.classmate.version>
 
     <dep.joda.version>2.9.4</dep.joda.version>
-    <dep.guava.version>19.0</dep.guava.version>
+    <dep.guava.version>22.0</dep.guava.version>
     <dep.protobuf-java.version>2.5.0</dep.protobuf-java.version>
     <dep.jdbi.version>2.73</dep.jdbi.version>
     <dep.liquibase.version>3.5.1</dep.liquibase.version>
@@ -129,6 +129,12 @@
     <snappy.version>0.3</snappy.version>
     <sentry.version>6.0.0</sentry.version>
     <horizon.version>0.0.20</horizon.version>
+    <dep.algebra.version>1.2</dep.algebra.version>
+    <dep.slack-client.version>1.0-SNAPSHOT</dep.slack-client.version>
+    <dep.algebra.version>1.2</dep.algebra.version>
+    <dep.immutables-hubspot.version>1.2</dep.immutables-hubspot.version>
+    <dep.immutables.version>2.2.10</dep.immutables.version>
+    <dep.reflections.version>0.9.11</dep.reflections.version>
     <commons-exec.version>1.1</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>
     <handlebars.version>1.3.1</handlebars.version>
@@ -335,6 +341,50 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <!-- HubSpot libraries -->
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>slack-base</artifactId>
+        <version>${dep.slack-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>algebra</artifactId>
+        <version>${dep.algebra.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonCore</artifactId>
+        <version>${horizon.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot</groupId>
+        <artifactId>HorizonNing</artifactId>
+        <version>${horizon.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>hubspot-style</artifactId>
+        <version>${dep.immutables-hubspot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>immutables-exceptions</artifactId>
+        <version>${dep.immutables-hubspot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>value</artifactId>
+        <version>${dep.immutables.version}</version>
+      </dependency>
+
+      <!-- Misc -->
+      <dependency>
+        <groupId>org.reflections</groupId>
+        <artifactId>reflections</artifactId>
+        <version>${dep.reflections.version}</version>
       </dependency>
 
       <!-- Maven libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dep.netty.version>4.1.8.Final</dep.netty.version>
     <dep.netty.epoll.classifier />
     <dep.objenesis.version>2.5.1</dep.objenesis.version>
-    <dep.reflections.version>0.9.10</dep.reflections.version>
+    <dep.reflections.version>0.9.11</dep.reflections.version>
     <dep.mockito.version>2.7.16</dep.mockito.version>
 
     <dep.jesos.version>1.1</dep.jesos.version>
@@ -128,13 +128,10 @@
     <ning.async.version>1.8.12</ning.async.version>
     <snappy.version>0.3</snappy.version>
     <sentry.version>6.0.0</sentry.version>
-    <horizon.version>0.0.20</horizon.version>
-    <dep.algebra.version>1.2</dep.algebra.version>
-    <dep.slack-client.version>1.0-SNAPSHOT</dep.slack-client.version>
+    <horizon.version>0.0.25</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>
     <dep.immutables-hubspot.version>1.2</dep.immutables-hubspot.version>
     <dep.immutables.version>2.2.10</dep.immutables.version>
-    <dep.reflections.version>0.9.11</dep.reflections.version>
     <commons-exec.version>1.1</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>
     <handlebars.version>1.3.1</handlebars.version>
@@ -341,50 +338,6 @@
             <artifactId>jsr305</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-
-      <!-- HubSpot libraries -->
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>slack-base</artifactId>
-        <version>${dep.slack-client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>algebra</artifactId>
-        <version>${dep.algebra.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonCore</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot</groupId>
-        <artifactId>HorizonNing</artifactId>
-        <version>${horizon.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot.immutables</groupId>
-        <artifactId>hubspot-style</artifactId>
-        <version>${dep.immutables-hubspot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.hubspot.immutables</groupId>
-        <artifactId>immutables-exceptions</artifactId>
-        <version>${dep.immutables-hubspot.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.immutables</groupId>
-        <artifactId>value</artifactId>
-        <version>${dep.immutables.version}</version>
-      </dependency>
-
-      <!-- Misc -->
-      <dependency>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections</artifactId>
-        <version>${dep.reflections.version}</version>
       </dependency>
 
       <!-- Maven libraries -->
@@ -1882,7 +1835,7 @@
       <dependency>
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
-        <version>2.1.15</version>
+        <version>${dep.immutables.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,9 @@
     <ning.async.version>1.8.12</ning.async.version>
     <snappy.version>0.3</snappy.version>
     <sentry.version>6.0.0</sentry.version>
-    <horizon.version>0.0.25</horizon.version>
+    <horizon.version>0.1.1</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>
-    <dep.immutables-hubspot.version>1.2</dep.immutables-hubspot.version>
+    <dep.hubspot-immutables.version>1.2</dep.hubspot-immutables.version>
     <dep.immutables.version>2.2.10</dep.immutables.version>
     <commons-exec.version>1.1</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>


### PR DESCRIPTION
This:

* Bumps the guava version: `19.0` -> `22.0`
* Adds `algebra` version (but not dep) at version `1.2`
* Adds hubspot immutables wrapper version (but not dep) at `1.2`
* Bumps immutables: `2.1.15` -> `2.2.10`
* Bumps reflections: `0.9.10` -> `0.9.11`
* Bumps Horizon `0.0.20` -> `0.0.25`

@stevegutz @jhaber 