### PR TITLE
Set basepom.test.memory to 1024m

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <basepom.dependency-management.dependencies>true</basepom.dependency-management.dependencies>
     <basepom.dependency-management.plugins>true</basepom.dependency-management.plugins>
 
+    <basepom.test.memory>1024m</basepom.test.memory>
     <basepom.test.timeout>900</basepom.test.timeout>
     <basepom.failsafe.timeout>900</basepom.failsafe.timeout>
 


### PR DESCRIPTION
This overrides the [default of `256m`](https://github.com/basepom/basepom/blob/basepom-25/foundation/pom.xml#L60) and should be enough for our current use case.

@jhaber @kmclarnon @Nimisha94