### PR TITLE
Upgrade surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
     <dep.plugin.dependency-management.version>0.8</dep.plugin.dependency-management.version>
     <dep.plugin.plugin.version>3.5</dep.plugin.plugin.version>
-    <dep.plugin.surefire.version>2.19.1</dep.plugin.surefire.version>
+    <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version>
 
     <dep.commons-beanutils.version>1.9.2</dep.commons-beanutils.version>
     <dep.commons-codec.version>1.10</dep.commons-codec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 
     <dep.plugin.dependency-management.version>0.8</dep.plugin.dependency-management.version>
     <dep.plugin.plugin.version>3.5</dep.plugin.plugin.version>
+    <!-- Overridden because basepom 25 is on 2.20.1, safe to remove if we upgrade basepom -->
     <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version>
 
     <dep.commons-beanutils.version>1.9.2</dep.commons-beanutils.version>


### PR DESCRIPTION
I renamed all of our failing `*Tests` classes to `*IT` so we should be able to upgrade without breaking stuff