### PR TITLE
Exclude jsr305 from guice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -821,12 +821,24 @@
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-testlib</artifactId>
         <version>${dep.guice.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-throwingproviders</artifactId>
         <version>${dep.guice.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- HTTP -->


### PR DESCRIPTION
This is required by guice `4.2.2`.

@jhaber @kmclarnon 