### PR TITLE
Set compiler release JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <project.build.targetJdk>1.8</project.build.targetJdk>
+    <project.build.releaseJdk>8</project.build.releaseJdk>
 
     <basepom.plugin.phase-really-executable>none</basepom.plugin.phase-really-executable>
     <basepom.jar.name.format>${project.artifactId}-${project.version}</basepom.jar.name.format>
@@ -43,6 +44,7 @@
     <basepom.test.timeout>900</basepom.test.timeout>
     <basepom.failsafe.timeout>900</basepom.failsafe.timeout>
 
+    <dep.plugin.compiler.version>3.8.0</dep.plugin.compiler.version>
     <dep.plugin.dependency-management.version>0.8</dep.plugin.dependency-management.version>
     <dep.plugin.failsafe.version>3.0.0-M3</dep.plugin.failsafe.version>
     <dep.plugin.plugin.version>3.5</dep.plugin.plugin.version>
@@ -2283,6 +2285,25 @@
               <artifactId>maven-javadoc-plugin</artifactId>
               <configuration>
                 <additionalparam>-Xdoclint:none</additionalparam>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>set-release-jdk</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <release>${project.build.releaseJdk}</release>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
Having this set makes it so that we compile against the class signatures of the release JDK. This prevents binary compatibility issues when compiling on JDK 11 and running on JDK 8. We observed this in the changing of many methods in `ByteBuffer` to return `ByteBuffer` instead of `Buffer`.

Setting `project.build.releaseJdk` to empty effectively disables this.

After we merge this, I'll do a release and move some of our open source projects over.

@jhaber @kmclarnon 