### PR TITLE
Don't exclude snakeyaml from jackson-dataformat-yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1443,12 +1443,6 @@
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>${dep.jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!-- jackson module -->


### PR DESCRIPTION
On`2.7.x`, `jackson-dataformat-yaml` bundles `snakeyaml`, making this dependency superfluous. However, in newer versions of jackson, this dependency should not be excluded. In order to properly test newer versions of jackson against our stack, we need to remove this exclusion.

@jhaber @kmclarnon 