### PR TITLE
Bump Apache HTTP deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
 
     <dep.assertj.version>3.4.1</dep.assertj.version>
     <dep.google.clients.version>1.20.0</dep.google.clients.version>
-    <dep.httpclient.version>4.5.5</dep.httpclient.version>
-    <dep.httpcore.version>4.4.9</dep.httpcore.version>
-    <dep.httpmime.version>4.5.5</dep.httpmime.version>
+    <dep.httpclient.version>4.5.10</dep.httpclient.version>
+    <dep.httpcore.version>4.4.12</dep.httpcore.version>
+    <dep.httpmime.version>4.5.10</dep.httpmime.version>
     <dep.javassist.version>3.22.0-GA</dep.javassist.version>
     <dep.mime4j.version>0.8.0</dep.mime4j.version>
     <dep.netty3.version>3.9.4.Final</dep.netty3.version>


### PR DESCRIPTION
Binary compatibility looks good, will test this out a bit before merging

## httpclient-4.5.5 → httpclient-4.5.10

No breaking changes

## httpcore-4.4.9 → httpcore-4.4.12

No breaking changes

## httpmime-4.5.5 → httpmime-4.5.10

No breaking changes

@kmclarnon @stevegutz 