### PR TITLE
Enable cobertura for coverage data collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,8 @@
 
     <basepom.check.skip-pom-lint>${basepom.check.skip-basic}</basepom.check.skip-pom-lint>
     <basepom.check.skip-license>true</basepom.check.skip-license>
-    <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
+    <basepom.check.skip-coverage>false</basepom.check.skip-coverage>
+    <basepom.check.fail-coverage>false</basepom.check.fail-coverage>
     <basepom.check.skip-prettier>true</basepom.check.skip-prettier>
 
     <basepom.fix.phase-prettier>never</basepom.fix.phase-prettier>


### PR DESCRIPTION
Changes:
`basepom.check.skip-coverage` to `true` to enable collection of coverage data for later processing.
`basepom.check.fail-coverage` to `false` as we'll not be failing builds. Its inherited from basepom foundation `basepom.check.fail-extended` via `basepom.check.fail-all` which is hard coded to `true`. 

As part of https://git.hubteam.com/HubSpot/BackendTesting/issues/20 we'll be surfacing the current unit test coverage of a project at PR time as a review item with the change to the coverage  that said PR will cause. We'll not be using this data to set coverage limits or fail builds