### PR TITLE
Upgrade surefire to 3.0.0-M5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dep.pmd.version>6.21.0</dep.pmd.version>
 
     <!-- Overridden because basepom 25 is on 2.20.1, safe to remove if we upgrade basepom -->
-    <dep.plugin.surefire.version>2.21.0</dep.plugin.surefire.version>
+    <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
 
     <dep.commons-beanutils.version>1.9.2</dep.commons-beanutils.version>
     <dep.commons-codec.version>1.10</dep.commons-codec.version>


### PR DESCRIPTION
The previous version doesn't run JUnit 5 tests 😢 

@jhaber @kmclarnon @Xcelled 