### PR TITLE
Manage org.xerial.snappy:snappy-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <mesos.version>1.1.2</mesos.version>
     <ning.async.version>1.8.12</ning.async.version>
     <snappy.version>0.3</snappy.version>
-    <dep.xerial.snappy.version>1.0.5</dep.xerial.snappy.version>
+    <dep.xerial.snappy.version>1.1.8.4</dep.xerial.snappy.version>
     <sentry.version>6.0.0</sentry.version>
     <horizon.version>0.1.1</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
     <dep.swagger.version>1.3.12</dep.swagger.version>
     <dep.testng.version>6.9.4</dep.testng.version>
-    <dep.xerial.snappy.version>1.1.8.4</dep.xerial.snappy.version>
+    <dep.xerial.snappy.version>1.1.10.5</dep.xerial.snappy.version>
     <dep.zookeeper.version>3.6.3</dep.zookeeper.version>
     <dropwizard.version>1.3.5</dropwizard.version>
     <handlebars.version>4.0.5</handlebars.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <mesos.version>1.1.2</mesos.version>
     <ning.async.version>1.8.12</ning.async.version>
     <snappy.version>0.3</snappy.version>
+    <dep.xerial.snappy.version>1.0.5</dep.xerial.snappy.version>
     <sentry.version>6.0.0</sentry.version>
     <horizon.version>0.1.1</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>
@@ -678,6 +679,12 @@
         <groupId>org.iq80.snappy</groupId>
         <artifactId>snappy</artifactId>
         <version>${snappy.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${dep.xerial.snappy.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@
     <horizon.version>0.1.1</horizon.version>
     <jukito.version>1.5</jukito.version>
     <mesos.version>1.1.2</mesos.version>
-    <ning.async.version>1.8.12</ning.async.version>
     <ning.async.version>1.9.38</ning.async.version>
     <ringleader.version>0.1.9</ringleader.version>
     <sentry.version>6.0.0</sentry.version>


### PR DESCRIPTION
This is the same version we use in parent-pom, so it should be safe to hoist this here.

@jhaber @kmclarnon @Xcelled 