### PR TITLE
Revert "Bump quartz from 2.2.1 to 2.3.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz</artifactId>
-        <version>2.3.2</version>
+        <version>2.2.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Reverts HubSpot/basepom#95
