### PR TITLE
Add hbase thirdparty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2008,6 +2008,13 @@
         <artifactId>apache-mime4j-dom</artifactId>
         <version>${dep.mime4j.version}</version>
       </dependency>
+
+      <!-- hbase -->
+      <dependency>
+        <groupId>org.apache.hbase.thirdparty</groupId>
+        <artifactId>hbase-shaded-protobuf</artifactId>
+        <version>3.5.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
We use this dep in multiple locations and each pom is defining it's
own version to 3.5.1. This consolidates all of those and ensures
we don't have version drift.

cc @stevegutz 