### PR TITLE
Upgrade to latest logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dep.junit-jupiter.version>5.8.1</dep.junit-jupiter.version>
     <dep.testng.version>6.9.4</dep.testng.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
-    <dep.logback.version>1.2.3</dep.logback.version>
+    <dep.logback.version>1.2.7</dep.logback.version>
     <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
 
     <dep.jackson.version>2.7.9</dep.jackson.version>


### PR DESCRIPTION
We're pretty out of date here, seems like it's worth an upgrade

## logback-core-1.2.3 → logback-core-1.2.7

| Type | Count |
| - | -: |
| Changed datatypes | 1 |
| Changed methods | 0 |
| Removed datatypes | 0 |
| Removed methods | 0 |

Looks like there was a source-compatible change to `LayoutWrappingEncoder` but don't think it will affect us:
> Parameter at index 0 to method setParent changed from ch.qos.logback.core.Appender<?> to ch.qos.logback.core.spi.ContextAware.

@stevegutz @kmclarnon @Xcelled @snommit-mit 