### PR TITLE
Upgrade to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <dep.junit-jupiter.version>5.8.1</dep.junit-jupiter.version>
     <dep.testng.version>6.9.4</dep.testng.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
-    <dep.logback.version>1.2.7</dep.logback.version>
+    <dep.logback.version>1.2.8</dep.logback.version>
     <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
 
     <dep.jackson.version>2.7.9</dep.jackson.version>


### PR DESCRIPTION
They actually just released 1.2.8 a few minutes ago and they recommend people upgrade to it. 

## logback-core-1.2.7 → logback-core-1.2.8

| Type | Count |
| - | -: |
| Changed datatypes | 0 |
| Changed methods | 0 |
| Removed datatypes | 19 |
| Removed methods | 0 |

All the removed classes are under `ch.qos.logback.core.db` which we don't use

@stevegutz @kmclarnon @Xcelled @snommit-mit