### PR TITLE
Add jsr305 exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,12 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java-util</artifactId>
         <version>${dep.protobuf-java.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Newer versions of protobuf-java-util include a dep on jsr305

@kmclarnon @stevegutz @Xcelled @snommit-mit 