### PR TITLE
Disable prettier:check for -DfixErrors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2414,6 +2414,7 @@
         </file>
       </activation>
       <properties>
+        <basepom.check.phase-prettier>never</basepom.check.phase-prettier>
         <basepom.fix.phase-prettier>validate</basepom.fix.phase-prettier>
       </properties>
     </profile>


### PR DESCRIPTION
Running `prettier:check` after `prettier:write` seems redundant and adds about 2 seconds to every local module build.

@stevegutz @Xcelled @snommit-mit @jhaber 