### PR TITLE
Bump commons-exec version to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <dep.jmh.version>1.21</dep.jmh.version>
     <dep.hubspot-immutables.version>1.2</dep.hubspot-immutables.version>
     <dep.immutables.version>2.5.6</dep.immutables.version>
-    <commons-exec.version>1.1</commons-exec.version>
+    <commons-exec.version>1.3</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>
     <handlebars.version>1.3.1</handlebars.version>
     <ringleader.version>0.1.4</ringleader.version>


### PR DESCRIPTION
Not in a rush to merge this PR, but wanted to put it out there.

There's several internal projects (mostly chrome webdriver + projects that use it) that have the 1.3 override - instead of dropping them to 1.1, figured it'd be better to upgrade than downgrade.

The [changelog](https://commons.apache.org/proper/commons-exec/changes-report.html) between 1.1 and 1.3 doesn't look like it contains any breaking changes, but as always wouldn't be surprised if there were unintended consequences.