### PR TITLE
update swagger-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,8 @@
     <dep.jesos.version>1.1</dep.jesos.version>
 
     <dep.swagger.version>1.3.12</dep.swagger.version>
-    <dep.swagger-plugin.version>2.3.2</dep.swagger-plugin.version>
+    <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
 
-    <dep.curator.version>2.8.0</dep.curator.version>
     <dropwizard.version>1.0.9</dropwizard.version>
     <dep.guava-retrying.version>2.0.0</dep.guava-retrying.version>
     <mesos.version>1.1.2</mesos.version>
@@ -631,31 +630,15 @@
         <artifactId>swagger-maven-plugin</artifactId>
         <version>${dep.swagger-plugin.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.wordnik</groupId>
-            <artifactId>swagger-jaxrs_2.10</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.wordnik</groupId>
-            <artifactId>swagger-jersey-jaxrs_2.10</artifactId>
-          </exclusion>
-        </exclusions>
+         <exclusion>
+           <groupId>log4j</groupId>
+           <artifactId>log4j</artifactId>
+           </exclusion>
+           <exclusion>
+           <groupId>commons-logging</groupId>
+           <artifactId>commons-logging</artifactId>
+           </exclusion>
+         </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <dep.swagger.version>1.3.12</dep.swagger.version>
     <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
 
+    <dep.curator.version>2.8.0</dep.curator.version>
     <dropwizard.version>1.0.9</dropwizard.version>
     <dep.guava-retrying.version>2.0.0</dep.guava-retrying.version>
     <mesos.version>1.1.2</mesos.version>


### PR DESCRIPTION
per HMR-1359 to address dependency diff, `swagger-maven-plugin` is only used by ApiTooling, so updated the basepom to match the version in ApiTooling