### PR TITLE
added dependency management for jackson-module-scala_2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1537,6 +1537,12 @@
         <version>${dep.jackson.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-scala_2.12</artifactId>
+        <version>${dep.jackson.version}</version>
+      </dependency>
+
       <!-- jackson jaxrs -->
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
Added jackson-module-scala dependency for Scala 2.12
Needed to satisfy dependencies on Apache Kafka code.

cc @stevegutz 