### PR TITLE
Upgrade hubspot immutables version 1.2 -> 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <horizon.version>0.1.1</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>
     <dep.jmh.version>1.21</dep.jmh.version>
-    <dep.hubspot-immutables.version>1.2</dep.hubspot-immutables.version>
+    <dep.hubspot-immutables.version>1.4</dep.hubspot-immutables.version>
     <dep.immutables.version>2.5.6</dep.immutables.version>
     <commons-exec.version>1.1</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <horizon.version>0.1.1</horizon.version>
     <dep.algebra.version>1.2</dep.algebra.version>
     <dep.jmh.version>1.21</dep.jmh.version>
-    <dep.hubspot-immutables.version>1.4</dep.hubspot-immutables.version>
+    <dep.hubspot-immutables.version>1.3</dep.hubspot-immutables.version>
     <dep.immutables.version>2.5.6</dep.immutables.version>
     <commons-exec.version>1.1</commons-exec.version>
     <jukito.version>1.4.1</jukito.version>


### PR DESCRIPTION
Can we upgrade the basepom version here to the new snapshot in order to utilize things like `WireSafeEnum` in public projects?

Release notes https://github.com/HubSpot/hubspot-immutables/releases/tag/hubspot-immutables-1.3