### PR TITLE
Add netty-codec-socks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -960,6 +960,11 @@
         <artifactId>netty-handler-proxy</artifactId>
         <version>${dep.netty.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-socks</artifactId>
+        <version>${dep.netty.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-codec-socks</artifactId>
+        <version>${dep.netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-common</artifactId>
         <version>${dep.netty.version}</version>
       </dependency>
@@ -958,11 +963,6 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler-proxy</artifactId>
-        <version>${dep.netty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-socks</artifactId>
         <version>${dep.netty.version}</version>
       </dependency>
 


### PR DESCRIPTION
This dependency already exists in `parent-pom`.  This PR simply adds this dependency up to `basepom` as well in order for it to be used in [NioImapClient](https://github.com/HubSpot/NioImapClient) (without having to add dependencyManagement there).

<img width="583" alt="image" src="https://github.com/HubSpot/basepom/assets/22668188/2ef588bb-4257-4917-86c2-fa0afb22eb1c">

cc @kmclarnon @kenbreeman 