### PR TITLE
Update logback to 1.2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <dep.junit-jupiter.version>5.8.1</dep.junit-jupiter.version>
     <dep.testng.version>6.9.4</dep.testng.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
-    <dep.logback.version>1.2.8</dep.logback.version>
+    <dep.logback.version>1.2.12</dep.logback.version>
     <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
 
     <dep.jackson.version>2.7.9</dep.jackson.version>


### PR DESCRIPTION
Upgrading logback from 1.2.8 to 1.2.12 which is the latest patch in the 1.2.x series.

Version 1.2.8 is vulnerable to CVE-2021-42550. Even in situations where this vulnerability cannot be exploited, it's still a good idea to upgrade, just to avoid overly eager vulnerability scanners from alerting.