### PR TITLE
set disableGenericsLinebreaks = true for prettier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2054,6 +2054,7 @@
             <nodeVersion>${basepom.prettier.node-version}</nodeVersion>
             <prettierJavaVersion>${basepom.prettier.prettier-java-version}</prettierJavaVersion>
             <printWidth>90</printWidth>
+            <disableGenericsLinebreaks>true</disableGenericsLinebreaks>
             <ignoreConfigFile>true</ignoreConfigFile>
             <ignoreEditorConfig>true</ignoreEditorConfig>
           </configuration>


### PR DESCRIPTION
this is a no-op for prettier v1.4.0, but setting it now will allow us to smoothly upgrade prettier to v2.+.

@jhaber 