### PR TITLE
re-add profile configuring compiler with --release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
   <packaging>pom</packaging>
 
   <properties>
-    <project.build.targetJdk>8</project.build.targetJdk>
+    <project.build.targetJdk>1.8</project.build.targetJdk>
+    <project.build.sourceJdk>${project.build.targetJdk}</project.build.sourceJdk>
+    <project.build.releaseJdk>8</project.build.releaseJdk>
 
     <basepom.plugin.phase-really-executable>none</basepom.plugin.phase-really-executable>
     <basepom.jar.name.format>${project.artifactId}-${project.version}</basepom.jar.name.format>
@@ -2402,6 +2404,26 @@
               <configuration>
                 <nodePath>/opt/build-deps/node-${basepom.prettier.node-version}/bin/node</nodePath>
                 <npmPath>/opt/build-deps/node-${basepom.prettier.node-version}/lib/node_modules/npm/bin/npm-cli.js</npmPath>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>set-release-jdk</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>${project.build.sourceJdk}</source>
+                <release>${project.build.releaseJdk}</release>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
i'd removed this erroneously, believing it was superceded by the `targetJdk` setting.

https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

@PtrTeixeira @stevie400 @Xcelled @suruuK @jhaber 
