### PR TITLE
Set mdep skip property based on skip-dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <basepom.check.skip-license>true</basepom.check.skip-license>
     <basepom.check.skip-coverage>true</basepom.check.skip-coverage>
     <basepom.check.skip-prettier>false</basepom.check.skip-prettier>
+    <mdep.analyze.skip>${basepom.check.skip-dependency}</mdep.analyze.skip>
 
     <basepom.deploy.skip>${maven.deploy.skip}</basepom.deploy.skip>
     <maven.deploy.skip>false</maven.deploy.skip>


### PR DESCRIPTION
There was an issue with certain invocations of the dependency-analyzer (and specifically of the `dependency:fix` invocation) not respecting this skip property when it should have, which lead to some overeager dependency pruning