### PR TITLE
use legacy staging url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2352,6 +2352,8 @@
       <properties>
         <basepom.deploy.skip>true</basepom.deploy.skip>
         <basepom.plugin.phase-really-executable>package</basepom.plugin.phase-really-executable>
+
+        <basepom.nexus-staging.staging-url>https://oss.sonatype.org/</basepom.nexus-staging.staging-url>
       </properties>
       <build>
         <pluginManagement>


### PR DESCRIPTION
i believe our project is still provisioned on the legacy oss sonatype repository, not the "s01" one.