### PR TITLE
Upgrade prettier-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2044,7 +2044,7 @@
         <plugin>
           <groupId>com.hubspot.maven.plugins</groupId>
           <artifactId>prettier-maven-plugin</artifactId>
-          <version>0.20</version>
+          <version>0.22</version>
           <configuration>
             <generateDiff>true</generateDiff>
             <nodeVersion>${basepom.prettier.node-version}</nodeVersion>


### PR DESCRIPTION
0.22 just got released which includes a fix for prettier-java 2.3+ (to not linebreak generics)

@PtrTeixeira @jaredstehler @ggs5427