### PR TITLE
Go back to using javadoc 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <basepom.nexus-staging.release-after-close>true</basepom.nexus-staging.release-after-close>
     <basepom.release.profiles>basepom.oss-release</basepom.release.profiles>
 
+    <dep.plugin.javadoc.version>3.1.0</dep.plugin.javadoc.version>
     <dep.plugin.plugin.version>3.9.0</dep.plugin.plugin.version>
 
     <dep.commons-beanutils.version>1.9.2</dep.commons-beanutils.version>


### PR DESCRIPTION
It seems like more recent versions of the maven-javadoc-plugin no longer support Java 1.8, which is what we still have as the release version for basepom

@jaredstehler @stevie400 @Xcelled @suruuK @ggs5427 