### PR TITLE
Change targetJdk from `1.8` to `8`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <project.build.targetJdk>1.8</project.build.targetJdk>
+    <project.build.targetJdk>8</project.build.targetJdk>
     <project.build.sourceJdk>${project.build.targetJdk}</project.build.sourceJdk>
     <project.build.releaseJdk>8</project.build.releaseJdk>
 


### PR DESCRIPTION
The issue with running javadoc appears to actually have been because newer versions of javadoc stopped recognizing `1.8` as `8` for the Java version here

Replacement for #147. Tested out with the `jinjava` repo, and this seems to be building fine and generating the javadoc fine

@jaredstehler @ggs5427