### PR TITLE
bump slf4j.version to 1.7.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dep.plugin.plugin.version>3.9.0</dep.plugin.plugin.version>
     <dep.protobuf-java.version>3.23.2</dep.protobuf-java.version>
     <dep.reflections.version>0.9.10</dep.reflections.version>
-    <dep.slf4j.version>1.7.25</dep.slf4j.version>
+    <dep.slf4j.version>1.7.32</dep.slf4j.version>
     <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
     <dep.swagger.version>1.3.12</dep.swagger.version>
     <dep.testng.version>6.9.4</dep.testng.version>


### PR DESCRIPTION
to align with the version of logback:

```
[ERROR] org.slf4j:slf4j-api: 1.7.25 (direct) - scope: compile - strategy: default
       1.7.25 expected by *com.hubspot.jinjava:jinjava*
       1.7.32 expected by ch.qos.logback:logback-classic
```
