### PR TITLE
Upgrade junit to 4.13.2, junit-jupiter to 5.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
     <dep.jmh.version>1.21</dep.jmh.version>
     <dep.jmxutils.version>1.18</dep.jmxutils.version>
     <dep.joda.version>2.10.8</dep.joda.version>
-    <dep.junit-jupiter.version>5.8.1</dep.junit-jupiter.version>
-    <dep.junit.version>4.12</dep.junit.version>
+    <dep.junit-jupiter.version>5.10.2</dep.junit-jupiter.version>
+    <dep.junit.version>4.13.2</dep.junit.version>
     <dep.liquibase-slf4j.version>2.0.0</dep.liquibase-slf4j.version>
     <dep.liquibase.version>3.5.1</dep.liquibase.version>
     <dep.log4j.version>1.2.17</dep.log4j.version>


### PR DESCRIPTION
junit 4.12 is vulnerable to CVE-2020-15250
