### PR TITLE
update all apache-commons deps to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,20 +60,20 @@
     <basepom.release.profiles>basepom.oss-release</basepom.release.profiles>
 
     <aws.sdk.version>1.12.643</aws.sdk.version>
-    <commons-exec.version>1.1</commons-exec.version>
+    <commons-exec.version>1.4.0</commons-exec.version>
     <dep.algebra.version>1.3</dep.algebra.version>
     <dep.apache-bval.version>0.5</dep.apache-bval.version>
     <dep.assertj.version>3.17.1</dep.assertj.version>
     <dep.classmate.version>1.3.1</dep.classmate.version>
     <dep.codahale-metrics.version>3.0.2</dep.codahale-metrics.version>
     <dep.commons-beanutils.version>1.9.4</dep.commons-beanutils.version>
-    <dep.commons-codec.version>1.10</dep.commons-codec.version>
+    <dep.commons-codec.version>1.17.0</dep.commons-codec.version>
     <dep.commons-collections.version>3.2.2</dep.commons-collections.version>
-    <dep.commons-collections4.version>4.1</dep.commons-collections4.version>
+    <dep.commons-collections4.version>4.4</dep.commons-collections4.version>
     <dep.commons-configuration.version>1.10</dep.commons-configuration.version>
-    <dep.commons-io.version>2.5</dep.commons-io.version>
+    <dep.commons-io.version>2.16.1</dep.commons-io.version>
     <dep.commons-lang.version>2.6</dep.commons-lang.version>
-    <dep.commons-lang3.version>3.9</dep.commons-lang3.version>
+    <dep.commons-lang3.version>3.14.0</dep.commons-lang3.version>
     <dep.commons-logging.version>1.2</dep.commons-logging.version>
     <dep.curator.version>5.3.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>


### PR DESCRIPTION
## Changed datatypes
`DiffBuilder.class`
org.apache.commons.lang3.builder
Class no longer implements interface 'org.apache.commons.lang3.builder.Builder<org.apache.commons.lang3.builder.DiffResult>'.
`ReflectionDiffBuilder.class`
org.apache.commons.lang3.builder

Class no longer implements interface 'org.apache.commons.lang3.builder.Builder<org.apache.commons.lang3.builder.DiffResult>'.
