### PR TITLE
Add `com.getsentry.raven:raven` to managed dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -627,6 +627,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.getsentry.raven</groupId>
+        <artifactId>raven</artifactId>
+        <version>8.0.2</version>
+      </dependency>
+
+      <dependency>
         <groupId>net.kencochrane.raven</groupId>
         <artifactId>raven</artifactId>
         <version>${sentry.version}</version>


### PR DESCRIPTION
The raven dependency under `net.kencochrane.raven` has been long deprecated, and will be removed in a future release.

Fixes https://github.com/HubSpot/basepom/issues/6

