### PR TITLE
Upgrade netty to 4.1.110

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dep.mockito.version>5.7.0</dep.mockito.version>
     <dep.mysql-connector-java.version>5.1.49</dep.mysql-connector-java.version>
     <dep.netty.epoll.classifier />
-    <dep.netty.version>4.1.8.Final</dep.netty.version>
+    <dep.netty.version>4.1.110.Final</dep.netty.version>
     <dep.netty3.version>3.9.4.Final</dep.netty3.version>
     <dep.objenesis.version>2.6</dep.objenesis.version>
     <dep.plugin.plugin.version>3.9.0</dep.plugin.plugin.version>


### PR DESCRIPTION
This upgrades all netty 4.x dependencies from `4.1.8.Final` to `4.1.110.Final`
