### PR TITLE
manage dependency `io.netty:netty-transport-classes-epoll`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -951,6 +951,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-epoll</artifactId>
+        <version>${dep.netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>${dep.netty.version}</version>
         <classifier>${dep.netty.epoll.classifier}</classifier>


### PR DESCRIPTION
Add managed dependency `io.netty:netty-transport-classes-epoll` at version `${dep.netty.version}`