### PR TITLE
upgrade basepom to 60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,16 @@
   <parent>
     <groupId>org.basepom</groupId>
     <artifactId>basepom-oss</artifactId>
-    <version>59</version>
+    <version>60</version>
   </parent>
 
   <groupId>com.hubspot</groupId>
   <artifactId>basepom</artifactId>
-  <version>59.12-SNAPSHOT</version>
+  <version>60.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
-    <project.build.sourceJdk>${project.build.targetJdk}</project.build.sourceJdk>
-    <project.build.releaseJdk>11</project.build.releaseJdk>
 
     <basepom.check.phase-checkstyle>validate</basepom.check.phase-checkstyle>
     <basepom.check.phase-coverage>pre-integration-test</basepom.check.phase-coverage>
@@ -2610,26 +2608,6 @@
                     <npmInstallCache>${user.home}/.m2/repository/.spotless-npm-install-cache</npmInstallCache>
                   </prettier>
                 </java>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <id>set-release-jdk</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>${project.build.sourceJdk}</source>
-                <release>${project.build.releaseJdk}</release>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
Also removes unnecessary build properties and profile:
* project.build.sourceJdk
* project.build.releaseJdk
