### PR TITLE
set javadoc to output html into target/apidocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2161,6 +2161,14 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <outputDirectory>${project.build.directory}</outputDirectory>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <configuration>
             <linkXRef>false</linkXRef>


### PR DESCRIPTION
`maven-javadoc-plugin` from `3.8.0...3.10.0` updates `outputDirectory` from `${project.build.directory}` to `${project.build.directory}/reports`, which results in the html output directory changing from `./target/apidocs` to `./target/reports/apidocs`. This breaks our internal javadoc site publishing tooling.

@stevie400 @jaredstehler @suruuK @ggs5427 @PtrTeixeira @tkindy
