### PR TITLE
remove unresolveable jetty managed deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1684,19 +1684,7 @@
 
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-monitor</artifactId>
-        <version>${dep.jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-http-spi</artifactId>
-        <version>${dep.jetty.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-jsp</artifactId>
         <version>${dep.jetty.version}</version>
       </dependency>
 


### PR DESCRIPTION
* `org.eclipse.jetty:jetty-monitor` -- no version > `9.3`
* `org.eclipse.jetty:jetty-jsp` -- no version > `9.2`
