### PR TITLE
default plugin goal prefix to project artifact id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2233,6 +2233,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
           <version>${dep.plugin.plugin.version}</version>
+          <configuration>
+            <goalPrefix>${project.artifactId}</goalPrefix>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
`maven-plugin-plugin` since `3.11` requires `goalPrefix` to be set: https://issues.apache.org/jira/browse/MPLUGIN-450 

this sets it to `project.artifactId` to prevent build errors; we don't use goal prefixes at hubspot.