### PR TITLE
Remove unused jackson modules that dont have updates beyond 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1463,12 +1463,6 @@
 
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-hibernate3</artifactId>
-        <version>2.12.7</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate4</artifactId>
         <version>${dep.jackson.version}</version>
       </dependency>
@@ -1599,12 +1593,6 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${dep.jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.module</groupId>
-        <artifactId>jackson-module-scala_2.10</artifactId>
-        <version>2.12.7</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1464,7 +1464,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-hibernate3</artifactId>
-        <version>${dep.jackson.version}</version>
+        <version>2.12.7</version>
       </dependency>
 
       <dependency>
@@ -1604,7 +1604,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-scala_2.10</artifactId>
-        <version>${dep.jackson.version}</version>
+        <version>2.12.7</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The hibernate3 and scala_2.10 jackson modules do not publish versions > 2.12 so those dependencies will not be found when dep.jackson.version is set to > 2.12. This PR deletes those deps since they are not used.

cc @stevie400 @Xcelled @jaredstehler