### PR TITLE
add extra-enforcer-rules as dep in maven-enforcer-plugin, with version prop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>
     <dep.dropwizard.version>1.3.5</dep.dropwizard.version>
     <dep.error-prone.version>2.35.1</dep.error-prone.version>
+    <dep.extra-enforcer-rules.version>1.9.0</dep.extra-enforcer-rules.version>
     <dep.findbugs.version>3.0.1</dep.findbugs.version>
     <dep.google.clients.version>1.20.0</dep.google.clients.version>
     <dep.guava-retrying.version>2.0.0</dep.guava-retrying.version>
@@ -2250,6 +2251,18 @@
               <ignoredDependency>org.glassfish.hk2.external:javax.inject</ignoredDependency>
             </ignoredDependencies>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>extra-enforcer-rules</artifactId>
+              <version>${dep.extra-enforcer-rules.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Adds the dependency `org.codehaus.mojo:extra-enforcer-rules` to all executions of the `maven-enforcer-plugin`, with version managed by property `dep.extra-enforcer-rules.version`.

