### PR TITLE
Run toolchains plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
   <properties>
     <project.build.targetJdk>11</project.build.targetJdk>
 
+    <!-- The JDK version used to run the build (eg, the version of javac to be used) -->
+    <!-- This determines what is going to be picked up by the toolchains plugin -->
+    <project.build.jdk.version>21</project.build.jdk.version>
+
+    <basepom.build.phase-toolchain>validate</basepom.build.phase-toolchain>
     <basepom.check.phase-checkstyle>validate</basepom.check.phase-checkstyle>
     <basepom.check.phase-coverage>pre-integration-test</basepom.check.phase-coverage>
     <basepom.check.phase-dependency-management>validate</basepom.check.phase-dependency-management>
@@ -2207,6 +2212,19 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>3.2.0</version>
+          <configuration>
+            <toolchains>
+              <jdk>
+                <version>${project.build.jdk.version}</version>
+              </jdk>
+            </toolchains>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <configuration>
@@ -2474,6 +2492,20 @@
               <goal>check</goal>
             </goals>
             <phase>${basepom.check.phase-pmd}</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>basepom.default</id>
+            <goals>
+              <goal>toolchain</goal>
+            </goals>
+            <phase>${basepom.build.phase-toolchain}</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <!-- The JDK version used to run the build (eg, the version of javac to be used) -->
     <!-- This determines what is going to be picked up by the toolchains plugin -->
-    <project.build.jdk.version>${project.build.targetJdk}</project.build.jdk.version>
+    <project.build.jdk.version>21</project.build.jdk.version>
 
     <basepom.build.phase-toolchain>validate</basepom.build.phase-toolchain>
     <basepom.check.phase-checkstyle>validate</basepom.check.phase-checkstyle>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <!-- The JDK version used to run the build (eg, the version of javac to be used) -->
     <!-- This determines what is going to be picked up by the toolchains plugin -->
-    <project.build.jdk.version>21</project.build.jdk.version>
+    <project.build.jdk.version>${project.build.targetJdk}</project.build.jdk.version>
 
     <basepom.build.phase-toolchain>validate</basepom.build.phase-toolchain>
     <basepom.check.phase-checkstyle>validate</basepom.check.phase-checkstyle>


### PR DESCRIPTION
Run the `toolchains` during the build in order to select the version of Java used in the build. This allows us to use a different version of Java to run Maven than the version used to compile the code.

The toolchains plugin was originally in the parent basepom, but was [removed](https://github.com/basepom/basepom/commit/900dd0f2fcfe76b303a5bf8d2eca43aba49186ad) some years ago, in favor of a `project.build.systemJdk` (which determines the minimum version of the system Java required). Unfortunately that doesn't really work for our use case, so adding the toolchains plugin back in.

I have run a Mothership mission internally to verify that this will be safe, but because this uses a point release it should be safe to merge regardless