### PR TITLE
Remove version pin of hbase-shaded-protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2083,13 +2083,6 @@
         <artifactId>apache-mime4j-dom</artifactId>
         <version>${dep.mime4j.version}</version>
       </dependency>
-
-      <!-- hbase -->
-      <dependency>
-        <groupId>org.apache.hbase.thirdparty</groupId>
-        <artifactId>hbase-shaded-protobuf</artifactId>
-        <version>3.5.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Having this package pinned to a specific version across hubspot is a stumbling block when upgrading HBase client versions. I'd prefer to let transitive dependency resolution pick a version. This package is only used in HBase-team stuff, so it's not going to be very disruptive if this change causes some builds to break.