### PR TITLE
Bump immutables version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <dep.httpmime.version>4.5.13</dep.httpmime.version>
     <dep.hubspot-basepom-policy.version>11.1</dep.hubspot-basepom-policy.version>
     <dep.hubspot-immutables.version>1.11.0</dep.hubspot-immutables.version>
-    <dep.immutables.version>2.10.1</dep.immutables.version>
+    <dep.immutables.version>2.11.2</dep.immutables.version>
     <dep.jackson-core.version>${dep.jackson.version}</dep.jackson-core.version>
     <dep.jackson-databind.version>${dep.jackson.version}</dep.jackson-databind.version>
     <dep.jackson.version>2.18.3</dep.jackson.version>


### PR DESCRIPTION
Bump the immutables version to 2.11.1. This specifically picks up some changes to jspecify. 

I'll need to update and release this, then update and release `hubspot-immutables` to pick up a new flag to turn off a new feature in `2.11`