### PR TITLE
bump dependency versions to align with parent-pom-dependency-management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,27 +66,27 @@
     <basepom.central-publishing.wait-until>published</basepom.central-publishing.wait-until>
     <basepom.release.profiles>basepom.central-release</basepom.release.profiles>
 
-    <dep.algebra.version>1.3</dep.algebra.version>
+    <dep.algebra.version>1.7.1</dep.algebra.version>
     <dep.apache-bval.version>0.5</dep.apache-bval.version>
-    <dep.asm.version>9.7.1</dep.asm.version>
+    <dep.asm.version>9.9.1</dep.asm.version>
     <dep.assertj.version>3.17.1</dep.assertj.version>
     <dep.aws.sdk.version>1.12.777</dep.aws.sdk.version>
     <dep.classmate.version>1.3.1</dep.classmate.version>
     <dep.codahale-metrics.version>3.0.2</dep.codahale-metrics.version>
-    <dep.commons-beanutils.version>1.9.4</dep.commons-beanutils.version>
+    <dep.commons-beanutils.version>1.11.0</dep.commons-beanutils.version>
     <dep.commons-codec.version>1.17.0</dep.commons-codec.version>
     <dep.commons-collections.version>3.2.2</dep.commons-collections.version>
-    <dep.commons-collections4.version>4.4</dep.commons-collections4.version>
+    <dep.commons-collections4.version>4.5.0</dep.commons-collections4.version>
     <dep.commons-configuration.version>1.10</dep.commons-configuration.version>
-    <dep.commons-exec.version>1.4.0</dep.commons-exec.version>
-    <dep.commons-io.version>2.16.1</dep.commons-io.version>
+    <dep.commons-exec.version>1.6.0</dep.commons-exec.version>
+    <dep.commons-io.version>2.21.0</dep.commons-io.version>
     <dep.commons-lang.version>2.6</dep.commons-lang.version>
-    <dep.commons-lang3.version>3.14.0</dep.commons-lang3.version>
+    <dep.commons-lang3.version>3.20.0</dep.commons-lang3.version>
     <dep.commons-logging.version>1.3.5</dep.commons-logging.version>
     <dep.curator.version>5.3.0</dep.curator.version>
     <dep.dropwizard-metrics.version>4.0.2</dep.dropwizard-metrics.version>
     <dep.dropwizard.version>1.3.5</dep.dropwizard.version>
-    <dep.error-prone.version>2.35.1</dep.error-prone.version>
+    <dep.error-prone.version>2.48.0</dep.error-prone.version>
     <dep.extra-enforcer-rules.version>1.9.0</dep.extra-enforcer-rules.version>
     <dep.findbugs.version>3.0.1</dep.findbugs.version>
     <dep.google.libraries.version>26.62.0</dep.google.libraries.version>
@@ -101,8 +101,8 @@
     <dep.httpcore.version>4.4.15</dep.httpcore.version>
     <dep.httpmime.version>4.5.13</dep.httpmime.version>
     <dep.hubspot-basepom-policy.version>11.1</dep.hubspot-basepom-policy.version>
-    <dep.hubspot-immutables.version>1.11.0</dep.hubspot-immutables.version>
-    <dep.immutables.version>2.10.1</dep.immutables.version>
+    <dep.hubspot-immutables.version>1.11.3</dep.hubspot-immutables.version>
+    <dep.immutables.version>2.11.2</dep.immutables.version>
     <dep.jackson.version>2.18.3</dep.jackson.version>
     <dep.jackson3.version>3.0.3</dep.jackson3.version>
     <dep.javassist.version>3.30.2-GA</dep.javassist.version>
@@ -110,7 +110,7 @@
     <dep.javax-servlet.version>3.1.0</dep.javax-servlet.version>
     <dep.javax-validation.version>1.1.0.Final</dep.javax-validation.version>
     <dep.jboss-logging.version>3.3.0.Final</dep.jboss-logging.version>
-    <dep.jdbi.version>2.73</dep.jdbi.version>
+    <dep.jdbi.version>2.76</dep.jdbi.version>
     <dep.jersey.version>1.19</dep.jersey.version>
     <dep.jersey2.version>2.25.1</dep.jersey2.version>
     <dep.jesos.version>1.1</dep.jesos.version>
@@ -124,24 +124,24 @@
     <dep.liquibase-slf4j.version>2.0.0</dep.liquibase-slf4j.version>
     <dep.liquibase.version>3.5.1</dep.liquibase.version>
     <dep.log4j.version>1.2.17</dep.log4j.version>
-    <dep.logback.version>1.3.14</dep.logback.version>
-    <dep.maven-core.version>3.9.12</dep.maven-core.version>
-    <dep.maven-resolver.version>1.9.25</dep.maven-resolver.version>
-    <dep.mesos.version>1.1.2</dep.mesos.version>
+    <dep.logback.version>1.3.15</dep.logback.version>
+    <dep.maven-core.version>3.9.14</dep.maven-core.version>
+    <dep.maven-resolver.version>1.9.27</dep.maven-resolver.version>
+    <dep.mesos.version>1.10.0</dep.mesos.version>
     <dep.mime4j.version>0.8.0</dep.mime4j.version>
-    <dep.mockito.version>5.7.0</dep.mockito.version>
+    <dep.mockito.version>5.15.2</dep.mockito.version>
     <dep.mysql-connector-java.version>5.1.49</dep.mysql-connector-java.version>
     <dep.netty.epoll.classifier />
-    <dep.netty.version>4.2.7.Final</dep.netty.version>
+    <dep.netty.version>4.2.9.Final</dep.netty.version>
     <dep.netty3.version>3.9.8.Final</dep.netty3.version>
     <dep.ning.async.version>1.9.38</dep.ning.async.version>
     <dep.objenesis.version>2.6</dep.objenesis.version>
     <dep.plexus.version>2.2.0</dep.plexus.version>
     <dep.plugin.plugin.version>3.15.2</dep.plugin.plugin.version>
-    <dep.protobuf-java.version>3.25.5</dep.protobuf-java.version>
+    <dep.protobuf-java.version>4.33.4</dep.protobuf-java.version>
     <dep.reflections.version>0.9.10</dep.reflections.version>
     <dep.slf4j.version>2.0.16</dep.slf4j.version>
-    <dep.sisu.version>0.9.0.M4</dep.sisu.version>
+    <dep.sisu.version>1.0.0</dep.sisu.version>
     <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
     <dep.swagger.version>1.3.12</dep.swagger.version>
     <dep.testng.version>6.9.4</dep.testng.version>


### PR DESCRIPTION
Bumps version properties to align with current values from `parent-pom-dependency-management`, keeping basepom in sync with the versions used across HubSpot services.

Updated versions:
- `dep.algebra.version`: 1.3 → 1.7.1
- `dep.asm.version`: 9.7.1 → 9.9.1
- `dep.commons-beanutils.version`: 1.9.4 → 1.11.0
- `dep.commons-collections4.version`: 4.4 → 4.5.0
- `dep.commons-exec.version`: 1.4.0 → 1.6.0
- `dep.commons-io.version`: 2.16.1 → 2.21.0
- `dep.commons-lang3.version`: 3.14.0 → 3.20.0
- `dep.error-prone.version`: 2.35.1 → 2.48.0
- `dep.guava-retrying.version`: 2.0.0 (unchanged effective version)
- `dep.hubspot-immutables.version`: 1.11.0 → 1.11.3
- `dep.immutables.version`: 2.10.1 → 2.11.2
- `dep.jdbi.version`: 2.73 → 2.76
- `dep.logback.version`: 1.3.14 → 1.3.15
- `dep.maven-core.version`: 3.9.12 → 3.9.14
- `dep.maven-resolver.version`: 1.9.25 → 1.9.27
- `dep.mesos.version`: 1.1.2 → 1.10.0
- `dep.mockito.version`: 5.7.0 → 5.15.2
- `dep.netty.version`: 4.2.7.Final → 4.2.9.Final
- `dep.protobuf-java.version`: 3.25.5 → 4.33.4
- `dep.sisu.version`: 0.9.0.M4 → 1.0.0
- `dep.zookeeper.version`: 3.6.3 (unchanged effective version)