### PR TITLE
bump basepom to 69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.basepom</groupId>
     <artifactId>basepom-oss</artifactId>
-    <version>68</version>
+    <version>69</version>
   </parent>
 
   <groupId>com.hubspot</groupId>
   <artifactId>basepom</artifactId>
-  <version>68.1-SNAPSHOT</version>
+  <version>69.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>HubSpot Basepom</name>


### PR DESCRIPTION
Bump spotbugs plugin to 4.9.8.3 (from 4.9.8.2)
Bump git-commit-id plugin to 9.1.0 (from 9.0.2)
Bump failsafe plugin to 3.5.5 (from 3.5.4)
Bump resources plugin to 3.5.0 (from 3.4.0)
Bump shade plugin to 3.6.2 (from 3.6.1)
Bump surefire plugin to 3.5.5 (from 3.5.4)
Bump surefire-report plugin to 3.5.5 (from 3.5.4)
Bump njord plugin to 0.9.4 (from 0.9.3)
Bump checkstyle to 13.4.0 (from 13.2.0)
Bump pmd to 7.23.0 (from 7.21.0)
Bump asciidoctorj-diagram to 3.2.1 (from 3.1.0)