### PR TITLE
bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <dep.hubspot-basepom-policy.version>11.1</dep.hubspot-basepom-policy.version>
     <dep.hubspot-immutables.version>1.11.3</dep.hubspot-immutables.version>
     <dep.immutables.version>2.11.2</dep.immutables.version>
-    <dep.jackson.version>2.18.3</dep.jackson.version>
+    <dep.jackson.version>2.21.3</dep.jackson.version>
     <dep.jackson3.version>3.0.3</dep.jackson3.version>
     <dep.javassist.version>3.30.2-GA</dep.javassist.version>
     <dep.javax-inject.version>1</dep.javax-inject.version>
@@ -129,7 +129,7 @@
     <dep.maven-resolver.version>1.9.27</dep.maven-resolver.version>
     <dep.mesos.version>1.10.0</dep.mesos.version>
     <dep.mime4j.version>0.8.0</dep.mime4j.version>
-    <dep.mockito.version>5.15.2</dep.mockito.version>
+    <dep.mockito.version>5.23.0</dep.mockito.version>
     <dep.mysql-connector-java.version>5.1.49</dep.mysql-connector-java.version>
     <dep.netty.epoll.classifier />
     <dep.netty.version>4.2.13.Final</dep.netty.version>
@@ -143,7 +143,7 @@
     <dep.slf4j.version>2.0.17</dep.slf4j.version>
     <dep.sisu.version>1.0.0</dep.sisu.version>
     <dep.swagger-plugin.version>3.1.8</dep.swagger-plugin.version>
-    <dep.swagger.version>1.3.12</dep.swagger.version>
+    <dep.swagger.version>1.5.13</dep.swagger.version>
     <dep.testng.version>6.9.4</dep.testng.version>
     <dep.xerial.snappy.version>1.1.10.5</dep.xerial.snappy.version>
     <dep.zookeeper.version>3.6.3</dep.zookeeper.version>


### PR DESCRIPTION
Keeps basepom in sync with the versions used across HubSpot services so that projects inheriting from this pom don't drift from the broader ecosystem.

- `dep.jackson.version`: 2.18.3 → 2.21.3
- `dep.mockito.version`: 5.15.2 → 5.23.0
- `dep.swagger.version`: 1.3.12 → 1.5.13